### PR TITLE
Print progress via ThirdParty lib

### DIFF
--- a/LibXboxOne/ThirdParty/ProgressBar.cs
+++ b/LibXboxOne/ThirdParty/ProgressBar.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Text;
+using System.Threading;
+
+/// <summary>
+/// An ASCII progress bar
+/// </summary>
+namespace LibXboxOne
+{
+    // Source: https://gist.github.com/DanielSWolf/0ab6a96899cc5377bf54
+    // License: MIT
+    public class ProgressBar : IDisposable, IProgress<long>
+    {
+        private const int blockCount = 30;
+        private readonly TimeSpan animationInterval = TimeSpan.FromSeconds(1.0 / 8);
+        private const string animation = @"|/-\";
+
+        private readonly Timer timer;
+
+        private long totalItems = 0;
+        private long currentItem = 0;
+        private string description = String.Empty;
+        private string currentText = string.Empty;
+        private bool disposed = false;
+        private int animationIndex = 0;
+
+        public ProgressBar(long items, string unitDescription="") {
+            totalItems = items;
+            description = unitDescription;
+            timer = new Timer(TimerHandler);
+
+            // A progress bar is only for temporary display in a console window.
+            // If the console output is redirected to a file, draw nothing.
+            // Otherwise, we'll end up with a lot of garbage in the target file.
+            if (!Console.IsOutputRedirected) {
+                ResetTimer();
+            }
+        }
+
+        public void Report(long current) {
+            Interlocked.Exchange(ref currentItem, current);
+        }
+
+        private void TimerHandler(object state) {
+            lock (timer) {
+                if (disposed) return;
+
+                double progress = (double)(currentItem + 1) / totalItems;
+                int progressBlockCount = (int) (progress * blockCount);
+                int percent = (int) (progress * 100);
+                string text = string.Format("{0,3}% [{1}{2}] {3}/{4} {5} {6}",
+                    percent,
+                    new string('#', progressBlockCount), new string('-', blockCount - progressBlockCount),
+                    currentItem,
+                    totalItems,
+                    description,
+                    animation[animationIndex++ % animation.Length]);
+                UpdateText(text);
+
+                ResetTimer();
+            }
+        }
+
+        private void UpdateText(string text) {
+            // Get length of common portion
+            int commonPrefixLength = 0;
+            int commonLength = Math.Min(currentText.Length, text.Length);
+            while (commonPrefixLength < commonLength && text[commonPrefixLength] == currentText[commonPrefixLength]) {
+                commonPrefixLength++;
+            }
+
+            // Backtrack to the first differing character
+            StringBuilder outputBuilder = new StringBuilder();
+            outputBuilder.Append('\b', currentText.Length - commonPrefixLength);
+
+            // Output new suffix
+            outputBuilder.Append(text.Substring(commonPrefixLength));
+
+            // If the new text is shorter than the old one: delete overlapping characters
+            int overlapCount = currentText.Length - text.Length;
+            if (overlapCount > 0) {
+                outputBuilder.Append(' ', overlapCount);
+                outputBuilder.Append('\b', overlapCount);
+            }
+
+            Console.Write(outputBuilder);
+            currentText = text;
+        }
+
+        private void ResetTimer() {
+            timer.Change(animationInterval, TimeSpan.FromMilliseconds(-1));
+        }
+
+        public void Dispose() {
+            lock (timer) {
+                disposed = true;
+                UpdateText(string.Empty);
+            }
+        }
+    }
+}

--- a/LibXboxOne/XVD/XVDFile.cs
+++ b/LibXboxOne/XVD/XVDFile.cs
@@ -332,37 +332,27 @@ namespace LibXboxOne
 
             // Perform crypto!
             if (PrintProgressToConsole)
-                Console.WriteLine($"\r\nCrypting section 0x{offset:X} - 0x{offset + length:X} (headerId: 0x{headerId}):");
+                Console.WriteLine($"\r\nCrypting section 0x{offset:X} - 0x{offset + length:X} (HeaderId: 0x{headerId:X}):");
 
             _io.Stream.Position = (long)offset;
-            var prevProgress = "";
-            for (uint page = 0; page < numPages; page++)
+
+            using (var progress = new ProgressBar((long)numPages, "pages"))
             {
-                if (PrintProgressToConsole)
+                for (uint page = 0; page < numPages; page++)
                 {
-                    var res = $"{(double)(page + 1) / numPages:0.00%}";
-                    if (res != prevProgress || page + 1 == numPages) // we don't need to print every page, only print when the percentage has actually changed
-                    {
-                        Console.Write($"\r  {res} {page + 1}/{numPages}");
-                        prevProgress = res;
-                    }
+                    if (PrintProgressToConsole)
+                        progress.Report((long)page);
+
+                    var transformedData = new byte[PAGE_SIZE];
+
+                    var pageOffset = _io.Stream.Position;
+                    var origData = _io.Reader.ReadBytes((int)PAGE_SIZE);
+
+                    cipher.TransformDataUnit(origData, 0, origData.Length, transformedData, 0, dataUnits?[(int)page] ?? page);
+
+                    _io.Stream.Position = pageOffset;
+                    _io.Writer.Write(transformedData);
                 }
-
-                var transformedData = new byte[PAGE_SIZE];
-
-                var pageOffset = _io.Stream.Position;
-                var origData = _io.Reader.ReadBytes((int)PAGE_SIZE);
-
-                cipher.TransformDataUnit(origData, 0, origData.Length, transformedData, 0, dataUnits?[(int)page] ?? page);
-
-                _io.Stream.Position = pageOffset;
-                _io.Writer.Write(transformedData);
-            }
-
-            if (PrintProgressToConsole)
-            {
-                Console.WriteLine();
-                Console.WriteLine();
             }
 
             return true;
@@ -821,45 +811,34 @@ namespace LibXboxOne
             ulong dataBlockCount = XvdMath.OffsetToPageNumber((ulong)_io.Stream.Length - UserDataOffset);
             var invalidBlocks = new List<ulong>();
 
-            var prevProgress = "";
-            for (ulong i = 0; i < dataBlockCount; i++)
+            using (var progress = new ProgressBar((long)dataBlockCount, "blocks"))
             {
-                if (PrintProgressToConsole)
+                for (ulong i = 0; i < dataBlockCount; i++)
                 {
-                    var res = $"{(double)(i + 1) / dataBlockCount:0.0%}";
-                    if (res != prevProgress || i + 1 == dataBlockCount) // we don't need to print every page, only print when the percentage has actually changed
-                    {
-                        Console.Write($"\r  {res} {i+1}/{dataBlockCount}");
-                        prevProgress = res;
-                    }
+                    if (PrintProgressToConsole)
+                        progress.Report((long)i);
+
+                    var hashEntryOffset = CalculateHashEntryOffsetForBlock(i, 0);
+                    _io.Stream.Position = (long)hashEntryOffset;
+
+                    byte[] oldhash = _io.Reader.ReadBytes((int)DataHashEntryLength);
+
+                    var dataToHashOffset = XvdMath.PageNumberToOffset(i) + UserDataOffset;
+                    _io.Stream.Position = (long)dataToHashOffset;
+
+                    byte[] data = _io.Reader.ReadBytes((int)PAGE_SIZE);
+                    byte[] hash = HashUtils.ComputeSha256(data);
+                    Array.Resize(ref hash, (int)DataHashEntryLength);
+
+                    if (hash.IsEqualTo(oldhash))
+                        continue;
+
+                    invalidBlocks.Add(i);
+                    if (!rehash)
+                        continue;
+                    _io.Stream.Position = (long)hashEntryOffset;
+                    _io.Writer.Write(hash);
                 }
-
-                var hashEntryOffset = CalculateHashEntryOffsetForBlock(i, 0);
-                _io.Stream.Position = (long)hashEntryOffset;
-
-                byte[] oldhash = _io.Reader.ReadBytes((int)DataHashEntryLength);
-
-                var dataToHashOffset = XvdMath.PageNumberToOffset(i) + UserDataOffset;
-                _io.Stream.Position = (long)dataToHashOffset;
-
-                byte[] data = _io.Reader.ReadBytes((int)PAGE_SIZE);
-                byte[] hash = HashUtils.ComputeSha256(data);
-                Array.Resize(ref hash, (int)DataHashEntryLength);
-
-                if (hash.IsEqualTo(oldhash))
-                    continue;
-
-                invalidBlocks.Add(i);
-                if (!rehash)
-                    continue;
-                _io.Stream.Position = (long)hashEntryOffset;
-                _io.Writer.Write(hash);
-            }
-
-            if (PrintProgressToConsole)
-            {
-                Console.WriteLine();
-                Console.WriteLine();
             }
 
             return invalidBlocks.ToArray();

--- a/XVDTool/Program.cs
+++ b/XVDTool/Program.cs
@@ -348,6 +348,7 @@ namespace XVDTool
                     Console.WriteLine(@"Error: output file already exists.");
                     return;
                 }
+                Console.WriteLine("Copying original file to output destination...");
                 File.Copy(filePath, outputFile);
                 filePath = outputFile;
             }


### PR DESCRIPTION
Source code of ProgressBar implementation: https://gist.github.com/DanielSWolf/0ab6a96899cc5377bf54

Looks something like this now
`28% [########----------------------] 2829/10023 pages \`

Features of the ThirdParty library (from https://stackoverflow.com/a/31193455):
- Works with redirected output
If you redirect the output of a console application (e.g., Program.exe > myfile.txt), most implementations will crash with an exception. That's because Console.CursorLeft and Console.SetCursorPosition() don't support redirected output.
- Thread-safe
- Fast
The Console class is notorious for its abysmal performance. Too many calls to it, and your application slows down. This class performs only 8 calls per second, no matter how often you report a progress update.