### PR TITLE
Fix CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,24 +89,6 @@ jobs:
       run: dotnet restore
     - name: Create publishable builds
       run: dotnet publish --no-restore --configuration Release ${{ needs.prepare.outputs.CommonBuildArgs }}
-    - name: Create publishable multi platform builds
-      shell: bash
-      run: |
-        for rid in linux-x64 win-x64 win-x86 osx-x64
-        do
-          release_name="XVDTool-${{ needs.prepare.outputs.AssemblySemVer }}-${rid}"
-          output_dir="release-${rid}"
-
-          for proj in XVDTool XBFSTool DurangoKeyExtractor
-          do
-            dotnet publish --configuration Release ${proj}/${proj}.csproj /p:PublishSingleFile=true --self-contained false --framework netcoreapp3.1 --runtime "${rid}" -o "${output_dir}" ${{ needs.prepare.outputs.CommonBuildArgs }}
-          done
-          
-          # Pack files
-          7z a -tzip "${release_name}.zip" "./${output_dir}/*" ./README.md ./xvd_info.md ./CHANGELOG.md
-          # Delete output directory
-          rm -r "$output_dir"
-        done
     - name: Copy files
       run: |
         mkdir ./release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,9 +70,9 @@ jobs:
     - name: Install dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build --configuration Release --no-restore ${{needs.prepare.outputs.CommonBuildArgs}}
+      run: dotnet build --configuration Release --no-restore
     - name: Test
-      run: dotnet test --no-restore --verbosity normal 
+      run: dotnet test --no-restore --verbosity normal
 
   build_publishable_archives:
     runs-on: ubuntu-latest
@@ -88,7 +88,7 @@ jobs:
     - name: Install dependencies
       run: dotnet restore
     - name: Create publishable builds
-      run: dotnet publish --no-restore --configuration Release 
+      run: dotnet publish --no-restore --configuration Release ${{ needs.prepare.outputs.CommonBuildArgs }}
     - name: Create publishable multi platform builds
       shell: bash
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,26 +3,26 @@ name: build
 on: [push, pull_request]
 
 jobs:
-  build:
+  prepare:
     runs-on: ubuntu-latest
-
+    outputs:
+      AssemblySemFileVer: ${{ steps.gitversion.outputs.assemblySemFileVer }}
+      SemVer: ${{ steps.gitversion.outputs.semVer }}
+      ShortSha: ${{ steps.gitversion.outputs.shortSha }}
+      CommonBuildArgs: /p:AssemblyVersion=${{ steps.gitversion.outputs.assemblySemFileVer }} /p:FileVersion=${{ steps.gitversion.outputs.assemblySemFileVer }} /p:InformationalVersion=${{ steps.gitversion.outputs.SemVer }}-${{ steps.gitversion.outputs.ShortSha }}
     steps:
     - uses: actions/checkout@v2
       with:
         submodules: 'recursive'
     - name: Fetch all history for all tags and branches
       run: git fetch --prune --unshallow
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 3.1.101
     - name: Install GitVersion
-      uses: gittools/actions/gitversion/setup@v0.9.2
+      uses: gittools/actions/gitversion/setup@v0.9.7
       with:
-        versionSpec: '5.2.x'
+        versionSpec: '5.6.x'
     - name: Use GitVersion
       id: gitversion # step id used as reference for output values
-      uses: gittools/actions/gitversion/execute@v0.9.2
+      uses: gittools/actions/gitversion/execute@v0.9.7
     - name: Show enumerated Git version strings
       run: |
         echo "Major: ${{ steps.gitversion.outputs.major }}"
@@ -55,25 +55,51 @@ jobs:
         echo "CommitsSinceVersionSource: ${{ steps.gitversion.outputs.commitsSinceVersionSource }}"
         echo "CommitsSinceVersionSourcePadded: ${{ steps.gitversion.outputs.commitsSinceVersionSourcePadded }}"
         echo "CommitDate: ${{ steps.gitversion.outputs.commitDate }}"
+
+  build_and_test:
+    runs-on: ubuntu-latest
+    needs: prepare
+    steps:
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.101
+    - uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
     - name: Install dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build --configuration Release --no-restore /p:AssemblyVersion=${{ steps.gitversion.outputs.assemblySemFileVer }} /p:FileVersion=${{ steps.gitversion.outputs.assemblySemFileVer }} /p:InformationalVersion=${{ steps.gitversion.outputs.SemVer }}-${{ steps.gitversion.outputs.ShortSha }}
+      run: dotnet build --configuration Release --no-restore ${{needs.prepare.outputs.CommonBuildArgs}}
     - name: Test
-      run: dotnet test --no-restore --verbosity normal /p:AssemblyVersion=${{ steps.gitversion.outputs.assemblySemFileVer }} /p:FileVersion=${{ steps.gitversion.outputs.assemblySemFileVer }} /p:InformationalVersion=${{ steps.gitversion.outputs.SemVer }}-${{ steps.gitversion.outputs.ShortSha }}
+      run: dotnet test --no-restore --verbosity normal 
+
+  build_publishable_archives:
+    runs-on: ubuntu-latest
+    needs: [prepare, build_and_test]
+    steps:
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.101
+    - uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
+    - name: Install dependencies
+      run: dotnet restore
     - name: Create publishable builds
-      run: dotnet publish --no-restore --configuration Release /p:AssemblyVersion=${{ steps.gitversion.outputs.assemblySemFileVer }} /p:FileVersion=${{ steps.gitversion.outputs.assemblySemFileVer }} /p:InformationalVersion=${{ steps.gitversion.outputs.SemVer }}-${{ steps.gitversion.outputs.ShortSha }}
+      run: dotnet publish --no-restore --configuration Release 
     - name: Create publishable multi platform builds
       shell: bash
       run: |
         for rid in linux-x64 win-x64 win-x86 osx-x64
         do
-          release_name="XVDTool-${{ steps.gitversion.outputs.assemblySemVer }}-${rid}"
+          release_name="XVDTool-${{ needs.prepare.outputs.AssemblySemVer }}-${rid}"
           output_dir="release-${rid}"
 
           for proj in XVDTool XBFSTool DurangoKeyExtractor
           do
-            dotnet publish --configuration Release ${proj}/${proj}.csproj /p:PublishSingleFile=true /p:AssemblyVersion=${{ steps.gitversion.outputs.assemblySemFileVer }} /p:FileVersion=${{ steps.gitversion.outputs.assemblySemFileVer }} /p:InformationalVersion=${{ steps.gitversion.outputs.SemVer }}-${{ steps.gitversion.outputs.ShortSha }} --self-contained false --framework netcoreapp3.1 --runtime "${rid}" -o "${output_dir}"
+            dotnet publish --configuration Release ${proj}/${proj}.csproj  ${{ needs.prepare.outputs.CommonBuildArgs }}
           done
           
           # Pack files
@@ -90,14 +116,23 @@ jobs:
       run: find .
     - name: Generate zip for release
       run: |
-        zip -j XVDTool-${{ steps.gitversion.outputs.assemblySemVer }}.zip ./release/*
+        zip -j XVDTool-${{ needs.prepare.outputs.AssemblySemVer }}.zip ./release/*
     - name: Upload  Artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: XVDTool-${{ steps.gitversion.outputs.SemVer }}-${{ steps.gitversion.outputs.ShortSha }}.zip
+        name: XVDTool-${{ needs.prepare.outputs.SemVer }}-${{ needs.prepare.outputs.ShortSha }}.zip
         path: ./release/
+
+  create_release:
+    runs-on: ubuntu-latest
+    needs: [prepare, build_publishable_archives]
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    steps:
+    - name: Download artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: XVDTool-${{ needs.prepare.outputs.SemVer }}-${{ needs.prepare.outputs.ShortSha }}.zip
     - name: Create release (on tag)
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       id: create_release
       uses: actions/create-release@v1
       env:
@@ -108,18 +143,16 @@ jobs:
         draft: false
         prerelease: false
     - name: Upload Release Asset
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       id: upload-release-asset 
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-        asset_path: ./XVDTool-${{ steps.gitversion.outputs.assemblySemVer }}.zip
-        asset_name: XVDTool-${{ steps.gitversion.outputs.assemblySemVer }}.zip
+        asset_path: ./XVDTool-${{ needs.prepare.outputs.AssemblySemVer }}.zip
+        asset_name: XVDTool-${{ needs.prepare.outputs.AssemblySemVer }}.zip
         asset_content_type: application/zip
     - name: Publish
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       uses: softprops/action-gh-release@v1
       with:
         files: "XVDTool-*.zip"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,7 @@ jobs:
 
           for proj in XVDTool XBFSTool DurangoKeyExtractor
           do
-            dotnet publish --configuration Release ${proj}/${proj}.csproj  ${{ needs.prepare.outputs.CommonBuildArgs }}
+            dotnet publish --configuration Release ${proj}/${proj}.csproj /p:PublishSingleFile=true --self-contained false --framework netcoreapp3.1 --runtime "${rid}" -o "${output_dir}" ${{ needs.prepare.outputs.CommonBuildArgs }}
           done
           
           # Pack files


### PR DESCRIPTION
* Splits the github workflow into smaller steps
* Ditches multi-platform build (we can simply require to install the .Net Core framework by now)