### PR TITLE
fix: IndexOutOfRangeException when trying to extract / pretty-print a XbfsFileEntry where filename is unknown

### DIFF
--- a/LibXboxOne.Tests/XbfsTests.cs
+++ b/LibXboxOne.Tests/XbfsTests.cs
@@ -37,5 +37,20 @@ namespace LibXboxOne.Tests
             header.Rehash();
             Assert.True(header.IsHashValid);
         }
+
+        [Fact]
+        public void TestXbfsOutOfBounds()
+        {
+            XbfsHeader header = GetHeader();
+
+            // Write a file entry past the known filenames array
+            header.Files[XbfsFile.XbfsFilenames.Length + 2] = new XbfsEntry(){
+                LBA=0, Length=1, Reserved=0
+            };
+
+            // Call to ToString will print filenames and should
+            // encouter a file that we don't know the filename of
+            header.ToString();
+        }
     }
 }

--- a/LibXboxOne/NAND/XbfsFile.cs
+++ b/LibXboxOne/NAND/XbfsFile.cs
@@ -70,6 +70,30 @@ namespace LibXboxOne.Nand
             return (uint)(offset / BlockSize);
         }
 
+        /// <summary>
+        /// Get Filename for XBFS filename from index
+        /// </summary>
+        /// <param name="index">Index of file</param>
+        /// <returns></returns>
+        public static string GetFilenameForIndex(int index)
+        {
+            if (index >= XbfsFilenames.Length) {
+                return null;
+            }
+
+            return XbfsFilenames[index];
+        }
+
+        /// <summary>
+        /// Get index for XBFS filename from filename
+        /// </summary>
+        /// <param name="name">Filename</param>
+        /// <returns>Returns >= 0 if file is found, -1 otherwise</returns>
+        public static int GetFileindexForName(string name)
+        {
+            return Array.IndexOf(XbfsFilenames, name);
+        }
+
         public Certificates.PspConsoleCert? ReadPspConsoleCertificate()
         {
             if (XbfsHeaders == null || XbfsHeaders.Count == 0)
@@ -122,9 +146,10 @@ namespace LibXboxOne.Nand
         // returns the size of the file if found
         public long SeekToFile(string fileName)
         {
-            int idx = Array.IndexOf(XbfsFilenames, fileName);
+            int idx = GetFileindexForName(fileName);
             if (idx < 0)
                 return 0;
+
             long size = 0;
             for (int i = 0; i < XbfsHeaders.Count; i++)
             {
@@ -185,7 +210,8 @@ namespace LibXboxOne.Nand
                     if (ent.Length == 0)
                         continue;
 
-                    string fileName = $"{FromLBA(ent.LBA):X}_{FromLBA(ent.Length):X}_{i}_{y}_{XbfsFilenames[y]}";
+                    var xbfsFilename = GetFilenameForIndex(y);
+                    string fileName = $"{FromLBA(ent.LBA):X}_{FromLBA(ent.Length):X}_{i}_{y}_{xbfsFilename}";
 
                     long read = 0;
                     long total = FromLBA(ent.Length);

--- a/LibXboxOne/NAND/XbfsHeader.cs
+++ b/LibXboxOne/NAND/XbfsHeader.cs
@@ -76,7 +76,7 @@ namespace LibXboxOne.Nand
                 XbfsEntry entry = Files[i];
                 if (entry.Length == 0)
                     continue;
-                b.AppendLine($"File {i}: {XbfsFile.XbfsFilenames[i]} {entry.ToString(formatted)}");
+                b.AppendLine($"File {i}: {XbfsFile.GetFilenameForIndex(i) ?? "<Unknown>"} {entry.ToString(formatted)}");
             }
 
             return b.ToString();


### PR DESCRIPTION
Fixes issue #45 