### PR TITLE
Xbfs: Series S/X support

### DIFF
--- a/LibXboxOne.Tests/XbfsTests.cs
+++ b/LibXboxOne.Tests/XbfsTests.cs
@@ -31,7 +31,7 @@ namespace LibXboxOne.Tests
         public void TestXbfsHeaderRehash()
         {
             XbfsHeader header = GetHeader();
-            header.Files[0].Length = 123;
+            header.Files[0].BlockCount = 123;
 
             Assert.False(header.IsHashValid);
             header.Rehash();
@@ -45,7 +45,7 @@ namespace LibXboxOne.Tests
 
             // Write a file entry past the known filenames array
             header.Files[XbfsFile.XbfsFilenames.Length + 2] = new XbfsEntry(){
-                LBA=0, Length=1, Reserved=0
+                LBA=0, BlockCount=1, Reserved=0
             };
 
             // Call to ToString will print filenames and should

--- a/LibXboxOne/NAND/XbfsEntry.cs
+++ b/LibXboxOne/NAND/XbfsEntry.cs
@@ -7,8 +7,17 @@ namespace LibXboxOne.Nand
     public struct XbfsEntry
     {
         /* 0x0 */ public uint LBA;
-        /* 0x4 */ public uint Length;
+        /* 0x4 */ public uint BlockCount;
         /* 0x8 */ public ulong Reserved;
+
+        public long Length => BlockCount * XbfsFile.BlockSize;
+
+        public long Offset(XbfsFlavor flavor) {
+            var offset = LBA * XbfsFile.BlockSize;
+            if (flavor == XbfsFlavor.XboxSeries && offset >= XbfsFile.SeriesOffsetDiff)
+                offset -= XbfsFile.SeriesOffsetDiff;
+            return offset;
+        }
 
         public override string ToString()
         {
@@ -18,8 +27,8 @@ namespace LibXboxOne.Nand
         public string ToString(bool formatted)
         {
             var b = new StringBuilder();
-            b.Append($"LBA: 0x{LBA:X} (0x{LBA * 0x1000:X}), ");
-            b.Append($"Length: 0x{Length:X} (0x{Length * 0x1000:X}), ");
+            b.Append($"LBA: 0x{LBA:X} (One: 0x{Offset(XbfsFlavor.XboxOne):X} Series: 0x{Offset(XbfsFlavor.XboxSeries):X}), ");
+            b.Append($"Length: 0x{BlockCount:X} (0x{Length:X}), ");
             b.Append($"Reserved: 0x{Reserved:X}");
 
             return b.ToString();

--- a/LibXboxOne/NAND/XbfsFile.cs
+++ b/LibXboxOne/NAND/XbfsFile.cs
@@ -24,7 +24,7 @@ namespace LibXboxOne.Nand
         public static readonly int SeriesOffsetDiff = 0x6000;
         public static readonly int BlockSize = 0x1000;
         public static readonly int[] XbfsOffsetsXboxOne = { 0x1_0000, 0x81_0000, 0x82_0000 };
-        public static readonly int[] XbfsOffsetsXboxSeries = { 0x1800_8000 };
+        public static readonly int[] XbfsOffsetsXboxSeries = { 0x0, 0x1800_8000 };
         public static string[] XbfsFilenames =
         {
             "1smcbl_a.bin", // 0

--- a/LibXboxOne/NAND/XbfsFile.cs
+++ b/LibXboxOne/NAND/XbfsFile.cs
@@ -70,6 +70,7 @@ namespace LibXboxOne.Nand
         public List<XbfsHeader> XbfsHeaders;
 
         public readonly string FilePath;
+        public long FileSize => _io.Stream.Length;
 
         public XbfsFile(string path)
         {
@@ -148,12 +149,12 @@ namespace LibXboxOne.Nand
 
         public bool Load()
         {
-            Flavor = FlavorFromSize(_io.Stream.Length);
+            Flavor = FlavorFromSize(FileSize);
 
             HeaderOffsets = Flavor switch {
                 XbfsFlavor.XboxOne => XbfsOffsetsXboxOne,
                 XbfsFlavor.XboxSeries => XbfsOffsetsXboxSeries,
-                _ => throw new InvalidDataException($"Invalid xbfs filesize: {_io.Stream.Length:X}"),
+                _ => throw new InvalidDataException($"Invalid xbfs filesize: {FileSize:X}"),
             };
 
             // read each XBFS header
@@ -286,6 +287,8 @@ namespace LibXboxOne.Nand
         {
             var b = new StringBuilder();
             b.AppendLine("XbfsFile");
+            b.AppendLine($"Flavor: {Flavor}");
+            b.AppendLine($"Size: 0x{FileSize:X} ({FileSize / 1024 / 1024} MB)");
             b.AppendLine();
             for (int i = 0; i < XbfsHeaders.Count; i++)
             {

--- a/LibXboxOne/NAND/XbfsHeader.cs
+++ b/LibXboxOne/NAND/XbfsHeader.cs
@@ -68,7 +68,7 @@ namespace LibXboxOne.Nand
             b.AppendLineSpace(fmt + $"Reserved18: 0x{Reserved18:X}");
             b.AppendLineSpace(fmt + $"Reserved3C0: {Reserved3C0.ToHexString()}");
             b.AppendLineSpace(fmt + $"System XVID: {SystemXVID}");
-            b.AppendLineSpace(fmt + $"XBFS header hash: {Environment.NewLine}{fmt}{XbfsHash.ToHexString()}");
+            b.AppendLineSpace(fmt + $"XBFS header hash: {Environment.NewLine}{fmt}{XbfsHash.ToHexString()} (Valid: {IsHashValid})");
             b.AppendLine();
 
             for(int i = 0; i < Files.Length; i++)


### PR DESCRIPTION
* Implement XBFS header position for Series S/X (1024MB) dumps
* Print xbfs header validity
* Auto-create folder for xbfs file extraction